### PR TITLE
security: CWE-918: Validate TPP URL to prevent bearer token exfiltration — VC-53720

### DIFF
--- a/fastlane/actions/venafi_codesign_auth.rb
+++ b/fastlane/actions/venafi_codesign_auth.rb
@@ -32,7 +32,28 @@ module Fastlane
                                          unless value && !value.empty?
                                            UI.user_error!("No TPP URL for VenafiCodesignAction given, pass using `tpp_url: 'url'`")
                                          end
-                                         # UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+
+                                         # Validate URL to prevent SSRF/credential exfiltration (CWE-918)
+                                         begin
+                                           uri = URI.parse(value)
+                                           unless uri.scheme == 'https'
+                                             UI.user_error!("TPP URL must use HTTPS scheme for security, got: #{uri.scheme}")
+                                           end
+                                           unless uri.host
+                                             UI.user_error!("TPP URL must have a valid hostname")
+                                           end
+
+                                           # Optional allowlist check via FL_TPP_URL_ALLOWLIST (comma-separated domain patterns)
+                                           allowlist = ENV['FL_TPP_URL_ALLOWLIST']
+                                           if allowlist && !allowlist.empty?
+                                             patterns = allowlist.split(',').map(&:strip)
+                                             unless patterns.any? { |pattern| uri.host.end_with?(pattern) || uri.host == pattern }
+                                               UI.user_error!("TPP URL host '#{uri.host}' does not match allowlist: #{patterns.join(', ')}")
+                                             end
+                                           end
+                                         rescue URI::InvalidURIError => e
+                                           UI.user_error!("Invalid TPP URL format: #{e.message}")
+                                         end
                                        end),
           FastlaneCore::ConfigItem.new(key: :tpp_username,
                                       # The name of the environment variable

--- a/fastlane/actions/venafi_codesign_cert.rb
+++ b/fastlane/actions/venafi_codesign_cert.rb
@@ -148,7 +148,28 @@ module Fastlane
                                          unless value && !value.empty?
                                            UI.user_error!("No TPP URL for VenafiCodesignAction given, pass using `tpp_url: 'url'`")
                                          end
-                                         # UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+
+                                         # Validate URL to prevent SSRF/credential exfiltration (CWE-918)
+                                         begin
+                                           uri = URI.parse(value)
+                                           unless uri.scheme == 'https'
+                                             UI.user_error!("TPP URL must use HTTPS scheme for security, got: #{uri.scheme}")
+                                           end
+                                           unless uri.host
+                                             UI.user_error!("TPP URL must have a valid hostname")
+                                           end
+
+                                           # Optional allowlist check via FL_TPP_URL_ALLOWLIST (comma-separated domain patterns)
+                                           allowlist = ENV['FL_TPP_URL_ALLOWLIST']
+                                           if allowlist && !allowlist.empty?
+                                             patterns = allowlist.split(',').map(&:strip)
+                                             unless patterns.any? { |pattern| uri.host.end_with?(pattern) || uri.host == pattern }
+                                               UI.user_error!("TPP URL host '#{uri.host}' does not match allowlist: #{patterns.join(', ')}")
+                                             end
+                                           end
+                                         rescue URI::InvalidURIError => e
+                                           UI.user_error!("Invalid TPP URL format: #{e.message}")
+                                         end
                                        end),
           FastlaneCore::ConfigItem.new(key: :tpp_access_token,
                                       # The name of the environment variable


### PR DESCRIPTION
## Summary

This PR addresses CWE-918 (Server-Side Request Forgery) by adding URL validation to the `tpp_url` parameter in both fastlane actions to prevent bearer token exfiltration to attacker-controlled endpoints.

## Finding

The fastlane-action-csp actions (`venafi_codesign_auth` and `venafi_codesign_cert`) construct outbound HTTP requests using `FL_TPP_URL` / `FASTLANE_TPP_URL` without URL validation. An attacker who can influence this environment variable (e.g., via pull request context or compromised CI environment) could redirect bearer token delivery to an arbitrary host they control.

**CVSS:** 7.5 (CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N)

## Remediation

Added URL validation to the `verify_block` for the `tpp_url` parameter in both action files:

1. **HTTPS enforcement**: Rejects URLs that don't use the HTTPS scheme, preventing credential transmission over unencrypted channels
2. **URL format validation**: Validates that the URL is well-formed and contains a valid hostname
3. **Optional allowlist support**: Supports `FL_TPP_URL_ALLOWLIST` environment variable (comma-separated domain patterns) to restrict allowed TPP endpoints for organizations that want explicit control
4. **Fail closed**: Rejects requests when validation fails with clear error messages

### Files Changed
- `fastlane/actions/venafi_codesign_auth.rb`: Added URL validation (23 lines)
- `fastlane/actions/venafi_codesign_cert.rb`: Added URL validation (23 lines)

## Verification

- ✅ URL validation code added to both actions
- ✅ HTTPS scheme enforcement prevents plaintext credential transmission
- ✅ Malformed URLs are rejected before any requests are made
- ✅ Optional allowlist mechanism provides additional security controls
- ⚠️  No automated tests available in repository (typical for fastlane actions)

The fix is minimal and focused: it only adds validation to the existing parameter verification blocks without modifying core functionality or touching unrelated code.