### PR TITLE
security: CWE-532: Prevent TPP credentials from appearing in logs — VC-53718

### DIFF
--- a/fastlane/actions/venafi_codesign_auth.rb
+++ b/fastlane/actions/venafi_codesign_auth.rb
@@ -7,7 +7,7 @@ module Fastlane
     class VenafiCodesignAuthAction < Action
       def self.run(params)
         # fastlane will take care of reading in the parameter and fetching the environment variable:
-        sh "tkdriverconfig getgrant --force --authurl=#{params[:tpp_url]}/vedauth --hsmurl=#{params[:tpp_url]}/vedhsm --username=#{params[:tpp_username]} --password=#{params[:tpp_password]}"
+        sh "tkdriverconfig getgrant --force --authurl=#{params[:tpp_url]}/vedauth --hsmurl=#{params[:tpp_url]}/vedhsm --username=#{params[:tpp_username]} --password=#{params[:tpp_password]}", log: false
         sh "tkdriverconfig sync"
         #sh "codesign -v --force -o runtime -s \"#{params[:identity]}\" #{params[:app_path]}"
         #sh "tkdriverconfig revokegrant --force"
@@ -50,6 +50,7 @@ module Fastlane
                                       env_name: 'FL_TPP_PASSWORD',
                                       # a short description of this parameter
                                       description: 'TPP Password for VenafiCodesignAction',
+                                      sensitive: true,
                                       verify_block: proc do |value|
                                         unless value && !value.empty?
                                           UI.user_error!("No TPP Password for VenafiCodesignAction given, pass using `password: 'password'`")

--- a/fastlane/actions/venafi_codesign_cert.rb
+++ b/fastlane/actions/venafi_codesign_cert.rb
@@ -155,6 +155,7 @@ module Fastlane
                                       env_name: 'FL_TPP_ACCESS_TOKEN',
                                       # a short description of this parameter
                                       description: 'TPP access token for VenafiCodesignCertAction',
+                                      sensitive: true,
                                       verify_block: proc do |value|
                                         unless value && !value.empty?
                                           UI.user_error!("No TPP access token for VenafiCodesignCertAction given, pass using `access_token: 'xxxxx'`")


### PR DESCRIPTION
## Summary

Fixes CWE-532 (Insertion of Sensitive Information into Log File) by preventing TPP password and access token from being logged to CI job output and fastlane parameter summary tables.

## Finding

**Severity:** High (CVSS 6.8)

The Venafi CodeSign Protect fastlane actions were logging sensitive credentials in two ways:

1. **Command echo to stdout**: The `sh` call in `venafi_codesign_auth.rb:10` used default options, causing fastlane to print the full `tkdriverconfig getgrant` command including `--password=<plaintext>` to stdout, which CI runners capture into persistent job logs.

2. **Parameter table disclosure**: The `:tpp_password` and `:tpp_access_token` ConfigItems lacked the `sensitive: true` flag, causing fastlane to print these secrets in cleartext in the "Summary for <action>" parameter table before execution.

Any principal with read access to CI job logs (typically any project member) could obtain the TPP password and access token, which grant signing capability on the Venafi CodeSign Protect platform.

## Remediation

Applied three targeted fixes:

1. **fastlane/actions/venafi_codesign_auth.rb:10** — Added `log: false` to the `sh` call to suppress command echo to stdout
2. **fastlane/actions/venafi_codesign_auth.rb:52** — Added `sensitive: true` to the `:tpp_password` ConfigItem
3. **fastlane/actions/venafi_codesign_cert.rb:157** — Added `sensitive: true` to the `:tpp_access_token` ConfigItem

These changes ensure both secrets are masked as `********` in parameter tables and prevent the password from appearing in command output logs.

## Verification

- Build/test status: Not run (fastlane plugin project without executable tests)
- Changed files: 2 (venafi_codesign_auth.rb, venafi_codesign_cert.rb)
- Lines changed: 3 insertions, 1 deletion

**Residual risk:** The `--password=` argument remains visible in the process table (`ps`) for the duration of the `tkdriverconfig` execution (CWE-214). Full mitigation requires the upstream CSP client to support credential delivery via stdin or environment variable. Operationally, ensure signing hosts run no untrusted co-resident processes.

**Post-deployment action required:** Rotate FL_TPP_PASSWORD and revoke any FL_TPP_ACCESS_TOKEN that appeared in retained CI job logs prior to this fix.