### PR TITLE
security: CWE-459: OAuth grant not revoked — VC-53717

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,20 +32,24 @@ platform :ios do
     )
   end
   lane :sign_venafi_csp do
-    venafi_codesign_auth(tpp_url: ENV['FASTLANE_TPP_URL'],
-                    tpp_username: ENV['FASTLANE_TPP_USERNAME'],
-                    tpp_password: ENV['FASTLANE_TPP_PASSWORD']
-                    )
-    build_app(
-      project: "SampleIOSApp.xcodeproj",
-      scheme: "SampleIOSApp",
-      output_name: "SampleIOSApp.ipa",
-      export_method: "development",
-      export_options: {
-        provisioningProfiles: {
-          "com.venafilab.SampleIOSApp" => "Venafi Test Profile"
+    begin
+      venafi_codesign_auth(tpp_url: ENV['FASTLANE_TPP_URL'],
+                      tpp_username: ENV['FASTLANE_TPP_USERNAME'],
+                      tpp_password: ENV['FASTLANE_TPP_PASSWORD']
+                      )
+      build_app(
+        project: "SampleIOSApp.xcodeproj",
+        scheme: "SampleIOSApp",
+        output_name: "SampleIOSApp.ipa",
+        export_method: "development",
+        export_options: {
+          provisioningProfiles: {
+            "com.venafilab.SampleIOSApp" => "Venafi Test Profile"
+          }
         }
-      }
-    )
+      )
+    ensure
+      venafi_codesign_cleanup
+    end
   end
 end

--- a/fastlane/actions/venafi_codesign_auth.rb
+++ b/fastlane/actions/venafi_codesign_auth.rb
@@ -10,7 +10,7 @@ module Fastlane
         sh "tkdriverconfig getgrant --force --authurl=#{params[:tpp_url]}/vedauth --hsmurl=#{params[:tpp_url]}/vedhsm --username=#{params[:tpp_username]} --password=#{params[:tpp_password]}"
         sh "tkdriverconfig sync"
         #sh "codesign -v --force -o runtime -s \"#{params[:identity]}\" #{params[:app_path]}"
-        #sh "tkdriverconfig revokegrant --force"
+        # Revocation moved to VenafiCodesignCleanupAction; use in lane's ensure block
       end
 
       def self.description
@@ -70,6 +70,28 @@ module Fastlane
 
       def self.authors
         ['zosocanuck']
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+    end
+
+    class VenafiCodesignCleanupAction < Action
+      def self.run(params)
+        begin
+          Actions.sh(['tkdriverconfig', 'revokegrant', '--force'], log: false)
+        rescue => e
+          UI.important("Venafi CSP grant revocation failed (may already be revoked): #{e.message}")
+        end
+      end
+
+      def self.description
+        'Revoke Venafi CodeSign Protect OAuth grant to clean up session credentials'
+      end
+
+      def self.available_options
+        []
       end
 
       def self.is_supported?(platform)


### PR DESCRIPTION
## Summary

Fixes CWE-459 (Incomplete Cleanup) in the Venafi CodeSign Protect authentication flow. The OAuth grant and synced keychain identities are now properly revoked when the signing lane exits, preventing credential leakage to later jobs on shared macOS build hosts.

## Finding

**Severity**: Medium (CVSS 6.6)  
**CWE**: CWE-459 (Incomplete Cleanup) / CWE-522 (Insufficiently Protected Credentials)

`VenafiCodesignAuthAction.run()` acquires a Venafi CSP OAuth grant via `tkdriverconfig getgrant` and installs HSM-backed signing identities into the login keychain via `tkdriverconfig sync`, but the cleanup call `tkdriverconfig revokegrant --force` was commented out (line 13). On persistent shared macOS runners that reuse the same OS user across jobs, any later job inherits the live grant and can sign arbitrary binaries with the victim's production keys without TPP credentials.

## Remediation

1. **Created `VenafiCodesignCleanupAction`**: New fastlane action that runs `tkdriverconfig revokegrant --force` with failure tolerance (rescue block) to ensure the grant is invalidated.

2. **Added `ensure` block to `sign_venafi_csp` lane**: Wrapped the lane body in `begin...ensure venafi_codesign_cleanup end` so revocation runs on both success and build failure.

The cleanup is implemented as a separate action (rather than uncommenting line 13) because revocation must occur *after* `build_app`, which is called by the lane, not by the auth action itself.

## Verification

- **Code path confirmed**: `getgrant` → `sync` → `build_app` → `ensure` → `revokegrant` now executes regardless of build outcome
- **Sink closed**: Later jobs cannot authenticate to the HSM without a valid grant; `codesign` will fail
- **No regression**: Build runs while grant is live; cleanup is failure-tolerant

**Residual considerations**:
- Consumers who vendor this action must add `venafi_codesign_cleanup` to their own lanes' ensure/after_all/error hooks
- Hard kill (SIGKILL) before ensure: mitigate with short TPP token TTL and runner post-job hooks